### PR TITLE
Fixing App.Config references from projects

### DIFF
--- a/Publisher/Publisher.csproj
+++ b/Publisher/Publisher.csproj
@@ -50,7 +50,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Subscriber/Subscriber.csproj
+++ b/Subscriber/Subscriber.csproj
@@ -54,7 +54,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I just remove the references pointing to missing App.config files in both Subscriber and Publisher projects to avoid failure during the solution build.
